### PR TITLE
Agrega endpoint para actualizar la cookie del scraper

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import express, { Application } from 'express';
+import bodyParser from 'body-parser';
 import figlet from 'figlet';
 import ApiRouter from './api/index';
 import {
@@ -25,6 +26,8 @@ const initializer: Initializer =
     .and(RunInitializer);
 
 let app: Application = express()
+  .use(bodyParser.json())
   .use('/', express.static(path.join(__dirname, '../public')))
   .use('/api', ApiRouter);
+
 export const Api: Application = initializer.init(app);

--- a/src/api/linkedin/controller/linkedin.controller.ts
+++ b/src/api/linkedin/controller/linkedin.controller.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from "@decorators/di";
 import { Response,} from 'express';
-import { Response as Res, Params, Controller, Get, Post, Middleware, Request as Req, Query } from '@decorators/express';
+import { Response as Res, Controller, Get, Post, Request as Req, Body, Query } from '@decorators/express';
 
 import ApiController from '../../../lib/controller';
 import { Levels, Logger, StdLogger } from "../../../lib/loggers";
@@ -23,6 +23,19 @@ export default class LinkedInController extends ApiController {
     super(logger, 'LinkedInController');
   }
 
+  @Post('/cookie')
+  async updateCookie(@Body() reqBody: Body | any, @Res() res: Response) {
+    try {
+      const { cookie } = reqBody
+      this.service.updateSessionCookie(cookie)
+      return res.sendStatus(200);
+    } catch (error) {
+      this.logger.log(Levels.ERROR, `Error updating cookie: ${error.message} `);
+      console.log(error)
+      res.status(500).json({ error });
+    }
+  }
+
   @Post('/upload', [SingleFileUploadMiddleware])
   async uploadCsvProfiles(@Req() req: Request | any, @Res() res: Response) {
     try {
@@ -41,7 +54,7 @@ export default class LinkedInController extends ApiController {
   @Get('/download', [SingleFileUploadMiddleware])
   async downloadCsvProfiles(@Query('filename') filename, @Res() res: Response) {
     const csv = this.uploadedCsv[filename]
-    if(!csv) return res.status(404).send()
+    if(!csv) return res.sendStatus(404);
     
     res.setHeader("Content-Type", "text/csv");
     res.setHeader("Content-Disposition", `attachment; filename=${filename}`);

--- a/src/api/linkedin/service/linkedin.service.ts
+++ b/src/api/linkedin/service/linkedin.service.ts
@@ -179,6 +179,10 @@ export default class LinkedInService extends ApiService {
     return batches;
   }
 
+  updateSessionCookie(cookie: string) {
+    this.scraper.updateSessionCookie(cookie);
+  }
+
   processProfiles(id: string, profiles: Array<{link: string}>): Promise<{fileName: string, content: string}> {
     return (async () => {
       const batches = this.batchify(profiles, 15)

--- a/src/initializers/error.initializer.ts
+++ b/src/initializers/error.initializer.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, NextFunction, Application } from 'express'
+import { ApiError } from 'src/lib/common/errors/errors';
 import { NotImplementedError } from '../lib/common/errors';
 import Initializer from './initializer';
 
@@ -6,8 +7,8 @@ const ErrorInitializer: Initializer = new Initializer(
   (app: Application) => {
     app.use((req: Request, res: Response, next: NextFunction) => 
       next(NotImplementedError(req)));
-    app.use((apiError: any, req: Request, res: Response, next: NextFunction) => 
-      res.status(apiError.statusCode).send(apiError.error));
+    app.use((apiError: ApiError, req: Request, res: Response, next: NextFunction) =>
+      res.status(apiError.statusCode || 520).send(apiError.error));
     return app;
   }
 );

--- a/src/lib/linkedin-profile-scraper/dist/index.d.ts
+++ b/src/lib/linkedin-profile-scraper/dist/index.d.ts
@@ -65,6 +65,7 @@ export declare class LinkedInProfileScraper {
     setup: () => Promise<void>;
     private createPage;
     private getBlockedHosts;
+    updateSessionCookie: (cookie: string) => void;
     close: (page?: puppeteer.Page | undefined) => Promise<void>;
     checkIfLoggedIn: () => Promise<void>;
     run: (profileUrl: string) => Promise<{

--- a/src/lib/linkedin-profile-scraper/dist/index.js
+++ b/src/lib/linkedin-profile-scraper/dist/index.js
@@ -36,6 +36,9 @@ class LinkedInProfileScraper {
             headless: true
         };
         this.browser = null;
+        this.updateSessionCookie = (cookie) => {
+          this.options.sessionCookieValue = cookie;
+        }
         this.setup = () => tslib_1.__awaiter(this, void 0, void 0, function* () {
             const logSection = 'setup';
             try {
@@ -212,6 +215,7 @@ class LinkedInProfileScraper {
             const logSection = 'checkIfLoggedIn';
             const page = yield this.createPage();
             utils_1.statusLog(logSection, 'Checking if we are still logged in...');
+            utils_1.statusLog(logSection, 'Cookie li_at: ' + this.options.sessionCookieValue);
             yield page.goto('https://www.linkedin.com/login', {
                 waitUntil: 'networkidle2',
                 timeout: this.options.timeout

--- a/src/lib/linkedin-profile-scraper/src/index.ts
+++ b/src/lib/linkedin-profile-scraper/src/index.ts
@@ -206,6 +206,10 @@ export class LinkedInProfileScraper {
     statusLog(logSection, `Using options: ${JSON.stringify(this.options)}`);
   }
 
+  public updateSessionCookie = (cookie: string) => {
+    this.options.sessionCookieValue = cookie;
+  }
+
   /**
    * Method to load Puppeteer in memory so we can re-use the browser instance.
    */


### PR DESCRIPTION
## Resumen
Dado que la cookie del usuario usado por el scraper vence, necesitamos alguna manera de actualizar este.
Este PR agrega un endpoint para actualizar dicha cookie usada para autenticarse contra LinkedIn.

### Aqui dejo un snippet para actualizar la cookie usando el endpoint:
```
COOKIE="the_li_at_cookie_value" && curl \
--location --request POST 'http://linkedin.nahual.com.ar:3000/api/linkedin/cookie' \
--header 'Content-Type: application/json' \
--data-raw "{ \"cookie\": \"$COOKIE\" }"
```

La cookie de LinkedIn se puede extraer haciendo: **Loguarse a Linkedin con chrome > Click derecho del mouse >  Inspect > Application > Cookies >  https://www.linkedin.com > Copiar Value de la fila con Name = li_at**
